### PR TITLE
run crucible-tracking.yaml on a self-hosted runner

### DIFF
--- a/.github/workflows/crucible-tracking.yaml
+++ b/.github/workflows/crucible-tracking.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   track:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
 
       - name: Generate token


### PR DESCRIPTION
- there is a dedicated self-hosted runner for project management purposes, but the job is not restricted to just that self-hosted runner in case there is additional capacity for parallel project management related jobs