### PR TITLE
have the git-testing workflow run on PRs

### DIFF
--- a/.github/workflows/git-testing.yaml
+++ b/.github/workflows/git-testing.yaml
@@ -1,7 +1,13 @@
 name: git-testing
 
 on:
+  pull_request:
+    branches: [ master ]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref }}/git-testing
+  cancel-in-progress: true
 
 jobs:
   default-checkout:


### PR DESCRIPTION
- this is in addition to allowing users to manually invoke it

- this is important because the state of the repositories is different between a PR and a manually invoked run against the primary branch